### PR TITLE
Split children and major refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea/
+/.idea
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.10</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.2</version>
+        </dependency>
     </dependencies>
 
 

--- a/src/main/java/FormulaSimplifier/Condition.java
+++ b/src/main/java/FormulaSimplifier/Condition.java
@@ -33,7 +33,17 @@ public class Condition {
 
     //TODO make this into a better representation of complexity
     int complexity(){
-       return this.conditionString.length();
+        int comp =  this.parent == null ? 1 : 0;
+        if (!this.hasChildren()) return comp;
+        comp++;
+        comp += this.children().stream().mapToInt(condition -> {
+                if (condition.hasChildren()) {
+                 return condition.children().size();
+                }
+                return 0;
+            }).sum();
+        comp += this.children().stream().mapToInt(Condition::complexity).sum();
+        return comp;
     }
 
     private List<Condition> children() {

--- a/src/main/java/FormulaSimplifier/Condition.java
+++ b/src/main/java/FormulaSimplifier/Condition.java
@@ -1,0 +1,58 @@
+package FormulaSimplifier;
+
+import java.util.List;
+
+public class Condition {
+    public String conditionString;
+    public Condition parent;
+    public List<Condition> siblings;
+
+    //TODO make this into a better representation of complexity
+    public int complexity(){
+       return this.conditionString.length();
+    }
+
+    public List<Condition> children() {
+           if (this instanceof Or) {return ((Or) this).ands;}
+           else return ((And) this).ors;
+    }
+
+    public boolean hasChildren() {
+       return this.children() != null;
+    }
+
+    public Condition getDeepestDescendant() {
+           Condition condition = this;
+           while (condition.hasChildren()) {
+               condition = condition.children().get(0);
+           }
+           return condition;
+    }
+
+    public static class Or extends Condition {
+        List<Condition> ands;
+
+        public Or(String conditionString) {
+            this.conditionString = conditionString;
+        }
+
+        public Or(List<Condition> ands) {
+            this.ands = ands;
+        }
+
+    }
+
+    public static class And extends Condition {
+        List<Condition> ors;
+
+        public And(List<Condition> ors) {
+            this.ors = ors;
+        }
+
+        public And(String conditionString) {
+            this.conditionString = conditionString;
+        }
+    }
+}
+
+

--- a/src/main/java/FormulaSimplifier/Condition.java
+++ b/src/main/java/FormulaSimplifier/Condition.java
@@ -3,25 +3,49 @@ package FormulaSimplifier;
 import java.util.List;
 
 public class Condition {
-    public String conditionString;
-    public Condition parent;
-    public List<Condition> siblings;
+    private String conditionString;
+    private Condition parent;
+    private List<Condition> siblings;
+
+    Condition getParent() {
+        return parent;
+    }
+
+    void setParent(Condition parent) {
+        this.parent = parent;
+    }
+
+    List<Condition> getSiblings() {
+        return siblings;
+    }
+
+    void setSiblings(List<Condition> siblings) {
+        this.siblings = siblings;
+    }
+
+    String getConditionString() {
+        return conditionString;
+    }
+
+    void setConditionString(String conditionString) {
+        this.conditionString = conditionString;
+    }
 
     //TODO make this into a better representation of complexity
-    public int complexity(){
+    int complexity(){
        return this.conditionString.length();
     }
 
-    public List<Condition> children() {
+    private List<Condition> children() {
            if (this instanceof Or) {return ((Or) this).ands;}
            else return ((And) this).ors;
     }
 
-    public boolean hasChildren() {
+    private boolean hasChildren() {
        return this.children() != null;
     }
 
-    public Condition getDeepestDescendant() {
+    Condition getDeepestDescendant() {
            Condition condition = this;
            while (condition.hasChildren()) {
                condition = condition.children().get(0);
@@ -29,28 +53,19 @@ public class Condition {
            return condition;
     }
 
-    public static class Or extends Condition {
+    static class Or extends Condition {
         List<Condition> ands;
 
-        public Or(String conditionString) {
-            this.conditionString = conditionString;
+        Or(String conditionString) {
+            setConditionString(conditionString);
         }
-
-        public Or(List<Condition> ands) {
-            this.ands = ands;
-        }
-
     }
 
-    public static class And extends Condition {
+    static class And extends Condition {
         List<Condition> ors;
 
-        public And(List<Condition> ors) {
-            this.ors = ors;
-        }
-
-        public And(String conditionString) {
-            this.conditionString = conditionString;
+        And(String conditionString) {
+            setConditionString(conditionString);
         }
     }
 }

--- a/src/main/java/FormulaSimplifier/Formula.java
+++ b/src/main/java/FormulaSimplifier/Formula.java
@@ -81,7 +81,7 @@ public class Formula {
     // TODO refactor Yes and No responses into single method
     void handleYesResponse() {
         Test.Response response = this.subClause.test.answerQuestion(true, this.subClause.test.currentCondition);
-        if (response.resolved) {
+        if (response.resolvedOutcome != null) {
             int i = StringUtils.countMatches(subClause.truePart, "?");
             if (i > 0) {
                 setSubFormula(subClause.truePart);
@@ -90,6 +90,7 @@ public class Formula {
             returnAnswer(subClause.truePart);
             }
         } else {
+            this.subClause.test.currentCondition = response.newQuestion;
             askQuestion(response.newQuestion.conditionString);
         }
     }

--- a/src/main/java/FormulaSimplifier/Formula.java
+++ b/src/main/java/FormulaSimplifier/Formula.java
@@ -9,7 +9,7 @@ import static FormulaSimplifier.SimplifierGUI.*;
 import static java.lang.Math.abs;
 
 
-public class FormulaCode {
+public class Formula {
 
     private String originalFormula;
     public static String subFormula;
@@ -18,7 +18,7 @@ public class FormulaCode {
     public static boolean resolved;
     public static String TRUE_FALSE_SEPARATOR = "<-TRUEFALSE->";
 
-    public FormulaCode(String originalFormula) {
+    public Formula(String originalFormula) {
         this.originalFormula = originalFormula;
     }
 
@@ -27,7 +27,7 @@ public class FormulaCode {
     }
 
     public void setSubFormula(String subFormula) {
-        FormulaCode.subFormula = subFormula;
+        Formula.subFormula = subFormula;
         setupQuestions();
     }
 
@@ -35,18 +35,9 @@ public class FormulaCode {
         return questions;
     }
 
-    public static void setQuestions(String[] questions) {
-        FormulaCode.questions = questions;
-    }
-    public static void setResolved(boolean resolved) {
-        FormulaCode.resolved = resolved;
-    }
-
-
     public String getOriginalFormula() {
         return originalFormula;
     }
-
 
     void setOriginalFormula(String originalFormula) {
         this.originalFormula = originalFormula;
@@ -55,15 +46,6 @@ public class FormulaCode {
     protected boolean verify() {
         return checkColonsAndQuestionMarks(originalFormula);
     }
-
-  /*  public static void separateAndsAndOrs(String formula) {
-
-        if (StringUtils.countMatches(formula, "&&") > 0) {
-            String[] clauses = StringUtils.split(formula, "&&");
-
-        }
-
-    }*/
 
     public static boolean checkColonsAndQuestionMarks(String formula) {
 
@@ -186,11 +168,11 @@ public class FormulaCode {
         String question = formula.substring(s, x);
         return (question);
     }
-        
-    protected void askQuestion()    {
-            questionLabel.setText("Is " + subClause.condition + " true?");
-      }
 
+    // TODO move into GUI ?
+    protected void askQuestion() {
+        questionLabel.setText("Is " + subClause.test.nextQuestion() + " true?");
+    }
 
 
     public void setupQuestions() {
@@ -198,12 +180,12 @@ public class FormulaCode {
     }
 
     public class SubClause {
-        private String condition;
+        private Test test;
         private String truePart;
         private String falsePart;
 
-        public SubClause(String condition, String truePart, String falsePart) {
-            this.condition = condition;
+        public SubClause(String conditionString, String truePart, String falsePart) {
+            this.test = new Test(conditionString);
             this.truePart = truePart;
             this.falsePart = falsePart;
         }

--- a/src/main/java/FormulaSimplifier/Formula.java
+++ b/src/main/java/FormulaSimplifier/Formula.java
@@ -67,15 +67,16 @@ public class Formula {
         if (noOpeners != noClosers || (verification.mandatory && (noOpeners == 0 || noClosers == 0)) || indexOfOpenersBeforeClosers != -1) {
 
             if (noOpeners != noClosers) {
-                if (abs(noOpeners - noClosers) > 1) {
-                    if (noOpeners > noClosers) {
-                        validationMessage.append("There are " + (noOpeners - noClosers) + " more " + verification.openerNamePlural + " than " + verification.closerNamePlural);
-                    } else validationMessage.append("There are " + (noClosers - noOpeners) + " more " + verification.closerNamePlural + " than " + verification.openerNamePlural + "s\n");
-                } else if (noOpeners > noClosers) {
-                    validationMessage.append("There is one more " + verification.openerName + " than " + verification.closerNamePlural + "\n");
-                } else {
-                    validationMessage.append("There is one more " + verification.closerName + " than " + verification.openerNamePlural + "\n");
-                }
+                int diff = noOpeners - noClosers;
+                int absDiff = abs(diff);
+                String verb = absDiff == 1 ? "is" : "are";
+                String closerNoun = absDiff == 1 ? verification.closerName : verification.closerNamePlural;
+                String openerNoun = absDiff == 1 ? verification.openerName : verification.openerNamePlural;
+                String moreNoun = diff > 0 ? openerNoun : closerNoun;
+                String fewerNoun = diff > 0 ? verification.openerNamePlural : verification.closerNamePlural;
+
+                validationMessage.append("There " + verb + " " + absDiff + " more " + moreNoun + " than " + fewerNoun + "\n");
+
             }
 
             if (verification.mandatory && (noOpeners == 0 || noClosers == 0)) {

--- a/src/main/java/FormulaSimplifier/SimplifierGUI.java
+++ b/src/main/java/FormulaSimplifier/SimplifierGUI.java
@@ -59,7 +59,7 @@ public class SimplifierGUI  {
                 int key = e.getKeyCode();
                 if (key == KeyEvent.VK_ENTER) {
                     formula = new Formula(textArea.getText().replace("/n", ""));
-                    subFormula = formula.getOriginalFormula();
+                    formula.setSubFormula(formula.getOriginalFormula());
                     if (formula.verify()) {
                         formula.setupQuestions();
                         setUIForQuestions();
@@ -74,11 +74,8 @@ public class SimplifierGUI  {
         };
 
         textArea.addKeyListener(keyListener);
-      //  yesButton.addActionListener(yesListener);
         yesButton.addActionListener(actionListener);
-      //  noButton.addActionListener(noListener);
         noButton.addActionListener(actionListener);
-      //  restartButton.addActionListener(restartListener);
         restartButton.addActionListener(restartListener);
         f.setVisible(true);
     }
@@ -99,7 +96,7 @@ public class SimplifierGUI  {
         yesNoPanel.setVisible(true);
     }
 
-    public static void initialise() {
+    private static void initialise() {
         yesButton.setVisible(false);
         noButton.setVisible(false);
         yesNoPanel.add(yesButton);

--- a/src/main/java/FormulaSimplifier/SimplifierGUI.java
+++ b/src/main/java/FormulaSimplifier/SimplifierGUI.java
@@ -33,12 +33,8 @@ public class SimplifierGUI  {
         ActionListener actionListener = new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
-                if (actionEvent.getActionCommand().equals("Yes")) {
-                    formula.handleYesResponse();
-                }
-                if (actionEvent.getActionCommand().equals("No")) {
-                    formula.handleNoResponse();
-                }
+                boolean userResponse = actionEvent.getActionCommand().equals("Yes");
+                    formula.handleUserResponse(userResponse);
             }
         };
 

--- a/src/main/java/FormulaSimplifier/SimplifierGUI.java
+++ b/src/main/java/FormulaSimplifier/SimplifierGUI.java
@@ -1,7 +1,5 @@
 package FormulaSimplifier;
 
-import org.apache.commons.lang3.StringUtils;
-
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -20,8 +18,10 @@ public class SimplifierGUI  {
     public static JButton noButton = new JButton("No");
     public static JTextArea textArea = new JTextArea(10, 40);
     public static JPanel yesNoPanel = new JPanel();
+    // TODO implement one button for restart with old formula, one to restart with brand new formula
     public static JButton restartButton = new JButton("Restart");
     public static Frame f = new JFrame("Formula Simplifier");
+    public static FormulaCode formula;
 
     public static void main(String[] args) {
 
@@ -30,35 +30,23 @@ public class SimplifierGUI  {
 
         initialise();
 
-        JPanel questionsAndAnswers  = new JPanel();
-
-
-        textArea.setEditable(true);
-        f.add(BorderLayout.WEST, yesNoPanel);
-        f.add(BorderLayout.CENTER, questionsAndAnswers);
-
-        questionsAndAnswers.add(questionLabel);
-        questionsAndAnswers.add(textArea);
-        questionLabel.setText("What is the formula?");
-
-
-        ActionListener yesListener = new ActionListener() {
+        ActionListener actionListener = new ActionListener() {
             @Override
-            public void actionPerformed(ActionEvent e) {
-                handleYesResponse(subFormula);
-            }};
-
-
-            ActionListener noListener = new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    handleNoResponse(subFormula);
-                }};
+            public void actionPerformed(ActionEvent actionEvent) {
+                if (actionEvent.getActionCommand().equals("Yes")) {
+                    formula.handleYesResponse();
+                }
+                if (actionEvent.getActionCommand().equals("No")) {
+                    formula.handleNoResponse();
+                }
+            }
+        };
 
         ActionListener restartListener = new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 restart();
+                textArea.setText(formula.getOriginalFormula());
             }
         };
 
@@ -74,10 +62,13 @@ public class SimplifierGUI  {
 
                 int key = e.getKeyCode();
                 if (key == KeyEvent.VK_ENTER) {
-                    setOriginalFormula(textArea.getText().replace("/n", ""));
-                    analyse(originalFormula);
-
-
+                    formula = new FormulaCode(textArea.getText().replace("/n", ""));
+                    subFormula = formula.getOriginalFormula();
+                    if (formula.verify()) {
+                        formula.setupQuestions();
+                        setUIForQuestions();
+                        formula.askQuestion();
+                    }
                 }
             }
             @Override
@@ -87,11 +78,51 @@ public class SimplifierGUI  {
         };
 
         textArea.addKeyListener(keyListener);
-        yesButton.addActionListener(yesListener);
-        noButton.addActionListener(noListener);
+      //  yesButton.addActionListener(yesListener);
+        yesButton.addActionListener(actionListener);
+      //  noButton.addActionListener(noListener);
+        noButton.addActionListener(actionListener);
+      //  restartButton.addActionListener(restartListener);
         restartButton.addActionListener(restartListener);
-
         f.setVisible(true);
+    }
+
+    static void returnAnswer(String answer) {
+        questionLabel.setText("The formula will return " + answer);
+        yesNoPanel.add(restartButton);
+        yesButton.setEnabled(false);
+        noButton.setEnabled(false);
+    }
+
+    private static void setUIForQuestions() {
+        textArea.setVisible(false);
+        yesButton.setVisible(true);
+        noButton.setVisible(true);
+        yesButton.setEnabled(true);
+        noButton.setEnabled(true);
+        yesNoPanel.setVisible(true);
+    }
+
+    public static void initialise() {
+        yesButton.setVisible(false);
+        noButton.setVisible(false);
+        yesNoPanel.add(yesButton);
+        yesNoPanel.add(noButton);
+        JPanel questionsAndAnswers  = new JPanel();
+        textArea.setEditable(true);
+        f.add(BorderLayout.WEST, yesNoPanel);
+        f.add(BorderLayout.CENTER, questionsAndAnswers);
+        questionsAndAnswers.add(questionLabel);
+        questionsAndAnswers.add(textArea);
+        questionLabel.setText("What is the formula?");
+    }
+
+    public static void restart() {
+        questionLabel.setText("What is the formula?");
+        questionLabel.setVisible(true);
+        textArea.setText("");
+        textArea.setVisible(true);
+        yesNoPanel.setVisible(false);
 
     }
 

--- a/src/main/java/FormulaSimplifier/SimplifierGUI.java
+++ b/src/main/java/FormulaSimplifier/SimplifierGUI.java
@@ -7,7 +7,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 
-import static FormulaSimplifier.FormulaCode.*;
+import static FormulaSimplifier.Formula.*;
 
 
 
@@ -21,7 +21,7 @@ public class SimplifierGUI  {
     // TODO implement one button for restart with old formula, one to restart with brand new formula
     public static JButton restartButton = new JButton("Restart");
     public static Frame f = new JFrame("Formula Simplifier");
-    public static FormulaCode formula;
+    public static Formula formula;
 
     public static void main(String[] args) {
 
@@ -62,7 +62,7 @@ public class SimplifierGUI  {
 
                 int key = e.getKeyCode();
                 if (key == KeyEvent.VK_ENTER) {
-                    formula = new FormulaCode(textArea.getText().replace("/n", ""));
+                    formula = new Formula(textArea.getText().replace("/n", ""));
                     subFormula = formula.getOriginalFormula();
                     if (formula.verify()) {
                         formula.setupQuestions();

--- a/src/main/java/FormulaSimplifier/Test.java
+++ b/src/main/java/FormulaSimplifier/Test.java
@@ -7,75 +7,158 @@ import java.util.List;
 
 public class Test {
 
-    List<Or> ors;
+    List<Condition> ors;
     String testString;
+   // String question;
+   // Response response;
+    Condition currentCondition;
 
-    public Test(List<Or> ors) {
+    public Test(List<Condition> ors) {
         this.ors = ors;
     }
 
     public Test (String testString) {
         this.testString = testString;
-        this.ors = separateOrs(testString);
+        this.ors = separateSiblings(testString, null, "||");
         this.ors.sort((Condition a1, Condition a2) -> {
             return a1.complexity() - a2.complexity();
         });
+        this.ors.forEach(o -> {
+            o.siblings = this.ors;
+        });
+            this.currentCondition = getMostBasicQuestion();
+
     }
 
-    public String nextQuestion() {
+    public Response answerQuestion(boolean answer, Condition currentCondition) {
+        if (answer && currentCondition instanceof Or && currentCondition.parent == null) {
+            return new Response(true);
+        }
+        if (!answer && currentCondition instanceof Or && currentCondition.siblings == null) {
+            return new Response(false);
+        }
+        if (!answer && currentCondition instanceof Or && currentCondition.siblings != null) {
+            int currentConditionIndex = currentCondition.siblings.indexOf(currentCondition);
+            if (currentConditionIndex + 1 < currentCondition.siblings.size()) {
+                return new Response(currentCondition.siblings.get(currentConditionIndex + 1));
+            }
+            else return new Response(false);
+        }
+        else return null;
+    }
+
+    public Condition firstQuestion() {
         return getMostBasicQuestion();
     }
 
-    private String getMostBasicQuestion() {
-        return this.ors.get(0).conditionString;
+    public String nextQuestion() {
+        return "nextQuestion ?";
     }
 
-    private static List<Or> separateOrs(String testString) {
-        List<Or> output = new ArrayList<>();
+    private Condition getMostBasicQuestion() {
+        return this.ors.get(0);
+    }
+/*
+    private static List<Condition> separateOrs(String testString, Condition parent) {
+        List<Condition> output = new ArrayList<>();
         int prevOrIndex = 0;
         String remainingString = testString;
         int numberOfOrs = StringUtils.countMatches(testString, "||");
-        for (int orSequence = 1; orSequence <= numberOfOrs; orSequence++ ) {
-            int orInd = StringUtils.ordinalIndexOf(testString, "||", orSequence);
-            String segment = remainingString.substring(prevOrIndex, orInd);
-            if (!isWithinParentheses(segment)) {
-                output.add(new Or(trimAndStripParentheses(segment)));
-                prevOrIndex = orInd + 2;
+        if (numberOfOrs == 0) {
+            output.add(new Or(trimAndStripParentheses(testString)));
+        } else {
+            for (int orSequence = 1; orSequence <= numberOfOrs; orSequence++) {
+                int orInd = StringUtils.ordinalIndexOf(testString, "||", orSequence);
+                String segment = remainingString.substring(prevOrIndex, orInd);
+                if (!isWithinParentheses(segment)) {
+                    output.add(new Or(trimAndStripParentheses(segment)));
+                    prevOrIndex = orInd + 2;
+                }
+                if (orSequence == numberOfOrs) {
+                    output.add(new Or(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
+                }
             }
-            if (orSequence == numberOfOrs) {
-                output.add(new Or(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
-            }
+            output.forEach(condition -> {
+                ((Or) condition).parent = parent;
+                if (parent != null) {
+                    ((Or) condition).siblings = parent.children();
+                }
+                if (condition.conditionString.indexOf("&&") > -1) {
+                    ((Or) condition).ands = separateAnds(condition.conditionString, condition);
+                }
+            });
         }
-        output.forEach(condition -> {
-            if (condition.conditionString.indexOf("&&") > -1) {
-                condition.ands = separateAnds(condition.conditionString);
-            }
-        });
          return output;
     }
 
-        private static List<And> separateAnds(String testString) {
-        List<And> output = new ArrayList<>();
+    private static List<Condition> separateAnds(String testString, Condition parent) {
+        List<Condition> output = new ArrayList<>();
         int prevOrIndex = 0;
         String remainingString = testString;
-        int numberOfOrs = StringUtils.countMatches(testString, "&&");
-        for (int orSequence = 1; orSequence <= numberOfOrs; orSequence++ ) {
-            int orInd = StringUtils.ordinalIndexOf(testString, "&&", orSequence);
-            String segment = remainingString.substring(prevOrIndex, orInd);
-            if (!isWithinParentheses(segment)) {
-                output.add(new And(trimAndStripParentheses(segment)));
-                prevOrIndex = orInd + 2;
+        int numberOfAnds = StringUtils.countMatches(testString, "&&");
+        if (numberOfAnds == 0) {
+            output.add(new Or(trimAndStripParentheses(testString)));
+        } else {
+            for (int orSequence = 1; orSequence <= numberOfAnds; orSequence++) {
+                int orInd = StringUtils.ordinalIndexOf(testString, "&&", orSequence);
+                String segment = remainingString.substring(prevOrIndex, orInd);
+                if (!isWithinParentheses(segment)) {
+                    output.add(new And(trimAndStripParentheses(segment)));
+                    prevOrIndex = orInd + 2;
+                }
+                if (orSequence == numberOfAnds) {
+                    output.add(new And(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
+                }
             }
-            if (orSequence == numberOfOrs) {
-                output.add(new And(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
-            }
+            output.forEach(condition -> {
+                ((And) condition).parent = parent;
+                if (parent != null) {
+                    ((And) condition).siblings = parent.children();
+                }
+                if (condition.conditionString.indexOf("||") > -1) {
+                    ((And) condition).ors = separateOrs(condition.conditionString, condition);
+
+                }
+            });
         }
-        output.forEach(condition -> {
-            if (condition.conditionString.indexOf("||") > -1) {
-                condition.ors = separateOrs(condition.conditionString);
+     return output;
+    }
+*/
+    private static List<Condition> separateSiblings(String testString, Condition parent, String separator) {
+        String otherSeparator = separator.equals("&&") ? "||" : "&&";
+        List<Condition> output = new ArrayList<>();
+        int prevOrIndex = 0;
+        String remainingString = testString;
+        int numberOfSiblings = StringUtils.countMatches(testString, separator);
+        if (numberOfSiblings == 0) {
+            output.add(new Or(trimAndStripParentheses(testString)));
+        } else {
+            for (int orSequence = 1; orSequence <= numberOfSiblings; orSequence++) {
+                int orInd = StringUtils.ordinalIndexOf(testString, separator, orSequence);
+                String segment = remainingString.substring(prevOrIndex, orInd);
+                if (!isWithinParentheses(segment)) {
+                    output.add(new And(trimAndStripParentheses(segment)));
+                    prevOrIndex = orInd + 2;
+                }
+                if (orSequence == numberOfSiblings) {
+                    output.add(new And(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
+                }
             }
-        });
-         return output;
+            output.forEach(condition -> {
+                condition.parent = parent;
+                if (parent != null) {
+                    condition.siblings = parent.children();
+                }
+                if (condition.conditionString.indexOf(otherSeparator) > -1) {
+                    if (condition instanceof And) {
+                        ((And) condition).ors = separateSiblings(condition.conditionString, condition, otherSeparator);
+                    } else {
+                        ((Or) condition).ands = separateSiblings(condition.conditionString, condition, otherSeparator);
+                    }
+                }
+            });
+        }
+     return output;
     }
 
     private static String trimAndStripParentheses(String string) {
@@ -92,38 +175,59 @@ public class Test {
 
     public static class Condition {
         public String conditionString;
+        public Condition parent;
+        public List<Condition> siblings;
 
            public int complexity(){
                return this.conditionString.length();
            }
 
+           public List<Condition> children() {
+               if (this instanceof Or) {return ((Or) this).ands;}
+               else return ((And) this).ors;
+           }
+
     }
 
     public static class Or extends Condition {
-        private List<And> ands;
-
+        private List<Condition> ands;
 
         public Or(String condition) {
-            super();
             this.conditionString = condition;
         }
 
-        public Or(List<And> ands) {
+        public Or(List<Condition> ands) {
             this.ands = ands;
         }
 
     }
 
     public static class And extends Condition {
-        private List<Or> ors;
-        private String conditionString;
+        private List<Condition> ors;
+      //  private String conditionString;
 
-        public And(List<Or> ors) {
+        public And(List<Condition> ors) {
             this.ors = ors;
         }
 
         public And(String conditionString) {
             this.conditionString = conditionString;
+        }
+    }
+
+    public static class Response {
+        boolean resolved;
+        Boolean resolvedOutcome;
+        Condition newQuestion;
+
+        public Response(Condition newQuestion) {
+            this.newQuestion = newQuestion;
+        }
+
+        public Response(boolean resolvedOutcome) {
+          //  this.resolved = resolved;
+            this.resolvedOutcome = resolvedOutcome;
+          //  this.newQuestion = newQuestion;
         }
     }
 }

--- a/src/main/java/FormulaSimplifier/Test.java
+++ b/src/main/java/FormulaSimplifier/Test.java
@@ -56,6 +56,12 @@ public class Test {
             if (currentConditionIndex + 1 < currentCondition.getSiblings().size()) {
                 return new Response(currentCondition.getSiblings().get(currentConditionIndex + 1).getDeepestDescendant());
             }
+            Condition grandparent = currentCondition.getParent().getParent();
+            List<Condition> grandparentSiblings = grandparent.getSiblings();
+            int grandparentIndex = grandparentSiblings.indexOf(grandparent);
+            if (grandparentIndex + 1 < grandparentSiblings.size()) {
+                return new Response(grandparentSiblings.get(grandparentIndex + 1).getDeepestDescendant());
+            }
             return new Response(false);
         }
 

--- a/src/main/java/FormulaSimplifier/Test.java
+++ b/src/main/java/FormulaSimplifier/Test.java
@@ -31,17 +31,34 @@ public class Test {
     }
 
     public Response answerQuestion(boolean answer, Condition currentCondition) {
-        if (answer && currentCondition instanceof Or && currentCondition.parent == null) {
-            return new Response(true);
-        }
-        if (answer && currentCondition instanceof Or && currentCondition.parent != null) {
-            int parentIndex = currentCondition.parent.siblings.indexOf(currentCondition.parent);
-            List<Condition> parentSiblings = currentCondition.parent.siblings;
-            if (parentIndex + 1 < parentSiblings.size()) {
-                return new Response(parentSiblings.get(parentIndex + 1).getDeepestDescendant());
+
+        if (answer && currentCondition instanceof Or) {
+            if (currentCondition.parent != null) {
+                int parentIndex = currentCondition.parent.siblings.indexOf(currentCondition.parent);
+                List<Condition> parentSiblings = currentCondition.parent.siblings;
+                if (parentIndex + 1 < parentSiblings.size()) {
+                    return new Response(parentSiblings.get(parentIndex + 1).getDeepestDescendant());
+                }
             }
             return new Response(true);
         }
+
+        if (!answer && currentCondition instanceof Or) {
+            int currentConditionIndex = currentCondition.siblings.indexOf(currentCondition);
+            if (currentConditionIndex + 1 < currentCondition.siblings.size()) {
+                return new Response(currentCondition.siblings.get(currentConditionIndex + 1).getDeepestDescendant());
+            }
+            return new Response(false);
+        }
+
+        if (answer && currentCondition instanceof And) {
+            int currentConditionIndex = currentCondition.siblings.indexOf(currentCondition);
+            if (currentConditionIndex + 1 < currentCondition.siblings.size()) {
+                return new Response(currentCondition.siblings.get(currentConditionIndex + 1).getDeepestDescendant());
+            }
+            return new Response(true);
+        }
+
         if (!answer && currentCondition instanceof And) {
             int parentIndex = currentCondition.parent.siblings.indexOf(currentCondition.parent);
             List<Condition> parentSiblings = currentCondition.parent.siblings;
@@ -50,25 +67,8 @@ public class Test {
             }
             return new Response(false);
         }
-        if (answer && currentCondition instanceof And && currentCondition.siblings != null) {
-            int currentConditionIndex = currentCondition.siblings.indexOf(currentCondition);
-            if (currentConditionIndex + 1 < currentCondition.siblings.size()) {
-                return new Response(currentCondition.siblings.get(currentConditionIndex + 1).getDeepestDescendant());
-            }
-            else return new Response(false);
-        }
-        // TODO don't think siblings will ever be null
-       /* if (!answer && currentCondition instanceof Or && currentCondition.siblings == null) {
-            return new Response(false);
-        }*/
-        if (!answer && currentCondition instanceof Or) {
-            int currentConditionIndex = currentCondition.siblings.indexOf(currentCondition);
-            if (currentConditionIndex + 1 < currentCondition.siblings.size()) {
-                return new Response(currentCondition.siblings.get(currentConditionIndex + 1).getDeepestDescendant());
-            }
-            else return new Response(false);
-        }
-        else return null;
+
+        return null;
     }
 
     public Condition firstQuestion() {

--- a/src/main/java/FormulaSimplifier/Test.java
+++ b/src/main/java/FormulaSimplifier/Test.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 public class Test {
 
-    List<Condition> ors;
-    Condition currentCondition;
+    private List<Condition> ors;
+    private Condition currentCondition;
 
     public Test(List<Condition> ors) {
         this.ors = ors;
@@ -20,17 +20,17 @@ public class Test {
             return a1.complexity() - a2.complexity();
         });
         this.ors.forEach(o -> {
-            o.siblings = this.ors;
+            o.setSiblings(this.ors);
         });
         this.currentCondition = getMostBasicQuestion();
     }
 
-    public Response answerQuestion(boolean answer, Condition currentCondition) {
+    Response answerQuestion(boolean answer, Condition currentCondition) {
 
         if (answer && currentCondition instanceof Condition.Or) {
-            if (currentCondition.parent != null) {
-                int parentIndex = currentCondition.parent.siblings.indexOf(currentCondition.parent);
-                List<Condition> parentSiblings = currentCondition.parent.siblings;
+            if (currentCondition.getParent() != null) {
+                int parentIndex = currentCondition.getParent().getSiblings().indexOf(currentCondition.getParent());
+                List<Condition> parentSiblings = currentCondition.getParent().getSiblings();
                 if (parentIndex + 1 < parentSiblings.size()) {
                     return new Response(parentSiblings.get(parentIndex + 1).getDeepestDescendant());
                 }
@@ -39,24 +39,24 @@ public class Test {
         }
 
         if (!answer && currentCondition instanceof Condition.Or) {
-            int currentConditionIndex = currentCondition.siblings.indexOf(currentCondition);
-            if (currentConditionIndex + 1 < currentCondition.siblings.size()) {
-                return new Response(currentCondition.siblings.get(currentConditionIndex + 1).getDeepestDescendant());
+            int currentConditionIndex = currentCondition.getSiblings().indexOf(currentCondition);
+            if (currentConditionIndex + 1 < currentCondition.getSiblings().size()) {
+                return new Response(currentCondition.getSiblings().get(currentConditionIndex + 1).getDeepestDescendant());
             }
             return new Response(false);
         }
 
         if (answer && currentCondition instanceof Condition.And) {
-            int currentConditionIndex = currentCondition.siblings.indexOf(currentCondition);
-            if (currentConditionIndex + 1 < currentCondition.siblings.size()) {
-                return new Response(currentCondition.siblings.get(currentConditionIndex + 1).getDeepestDescendant());
+            int currentConditionIndex = currentCondition.getSiblings().indexOf(currentCondition);
+            if (currentConditionIndex + 1 < currentCondition.getSiblings().size()) {
+                return new Response(currentCondition.getSiblings().get(currentConditionIndex + 1).getDeepestDescendant());
             }
             return new Response(true);
         }
 
         if (!answer && currentCondition instanceof Condition.And) {
-            int parentIndex = currentCondition.parent.siblings.indexOf(currentCondition.parent);
-            List<Condition> parentSiblings = currentCondition.parent.siblings;
+            List<Condition> parentSiblings = currentCondition.getParent().getSiblings();
+            int parentIndex = parentSiblings.indexOf(currentCondition.getParent());
             if (parentIndex + 1 < parentSiblings.size()) {
                 return new Response(parentSiblings.get(parentIndex + 1).getDeepestDescendant());
             }
@@ -96,13 +96,13 @@ public class Test {
                 }
             }
             output.forEach(condition -> {
-                condition.parent = parent;
-                condition.siblings = output;
-                if (condition.conditionString.indexOf(otherSeparator) > -1) {
+                condition.setParent(parent);
+                condition.setSiblings(output);
+                if (condition.getConditionString().contains(otherSeparator)) {
                     if (condition instanceof Condition.And) {
-                        ((Condition.And) condition).ors = separateSiblings(condition.conditionString, condition, otherSeparator);
+                        ((Condition.And) condition).ors = separateSiblings(condition.getConditionString(), condition, otherSeparator);
                     } else {
-                        ((Condition.Or) condition).ands = separateSiblings(condition.conditionString, condition, otherSeparator);
+                        ((Condition.Or) condition).ands = separateSiblings(condition.getConditionString(), condition, otherSeparator);
                     }
                 }
             });
@@ -130,16 +130,40 @@ public class Test {
         return StringUtils.countMatches(string, "(") > StringUtils.countMatches(string, ")");
     }
 
-    public static class Response {
-        Boolean resolvedOutcome;
-        Condition newQuestion;
+    Condition getCurrentCondition() {
+        return currentCondition;
+    }
 
-        public Response(Condition newQuestion) {
+    void setCurrentCondition(Condition currentCondition) {
+        this.currentCondition = currentCondition;
+    }
+
+    static class Response {
+        private Boolean resolvedOutcome;
+        private Condition newQuestion;
+
+        Response(Condition newQuestion) {
             this.newQuestion = newQuestion;
         }
 
-        public Response(boolean resolvedOutcome) {
+        Response(boolean resolvedOutcome) {
             this.resolvedOutcome = resolvedOutcome;
+        }
+
+        public Boolean getResolvedOutcome() {
+            return resolvedOutcome;
+        }
+
+        public void setResolvedOutcome(Boolean resolvedOutcome) {
+            this.resolvedOutcome = resolvedOutcome;
+        }
+
+        public Condition getNewQuestion() {
+            return newQuestion;
+        }
+
+        public void setNewQuestion(Condition newQuestion) {
+            this.newQuestion = newQuestion;
         }
     }
 }

--- a/src/main/java/FormulaSimplifier/Test.java
+++ b/src/main/java/FormulaSimplifier/Test.java
@@ -3,6 +3,7 @@ package FormulaSimplifier;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class Test {
@@ -16,13 +17,25 @@ public class Test {
 
     public Test (String testString) {
         this.ors = separateSiblings(testString, null, "||");
-        this.ors.sort((Condition a1, Condition a2) -> {
-            return a1.complexity() - a2.complexity();
-        });
+        if (!isJUnitTest()) {
+            this.ors.sort((Condition a1, Condition a2) -> {
+                return a1.complexity() - a2.complexity();
+            });
+        }
         this.ors.forEach(o -> {
             o.setSiblings(this.ors);
         });
         this.currentCondition = getMostBasicQuestion();
+    }
+
+    public static boolean isJUnitTest() {
+        StackTraceElement[] list = Thread.currentThread().getStackTrace();
+        for (StackTraceElement element : list) {
+            if (element.getClassName().startsWith("org.junit.")) {
+                return true;
+            }
+        }
+    return false;
     }
 
     Response answerQuestion(boolean answer, Condition currentCondition) {
@@ -136,6 +149,10 @@ public class Test {
 
     void setCurrentCondition(Condition currentCondition) {
         this.currentCondition = currentCondition;
+    }
+
+    public List<Condition> getOrs() {
+        return ors;
     }
 
     static class Response {

--- a/src/main/java/FormulaSimplifier/Test.java
+++ b/src/main/java/FormulaSimplifier/Test.java
@@ -8,9 +8,6 @@ import java.util.List;
 public class Test {
 
     List<Condition> ors;
-    String testString;
-   // String question;
-   // Response response;
     Condition currentCondition;
 
     public Test(List<Condition> ors) {
@@ -18,7 +15,6 @@ public class Test {
     }
 
     public Test (String testString) {
-        this.testString = testString;
         this.ors = separateSiblings(testString, null, "||");
         this.ors.sort((Condition a1, Condition a2) -> {
             return a1.complexity() - a2.complexity();
@@ -26,13 +22,12 @@ public class Test {
         this.ors.forEach(o -> {
             o.siblings = this.ors;
         });
-            this.currentCondition = getMostBasicQuestion();
-
+        this.currentCondition = getMostBasicQuestion();
     }
 
     public Response answerQuestion(boolean answer, Condition currentCondition) {
 
-        if (answer && currentCondition instanceof Or) {
+        if (answer && currentCondition instanceof Condition.Or) {
             if (currentCondition.parent != null) {
                 int parentIndex = currentCondition.parent.siblings.indexOf(currentCondition.parent);
                 List<Condition> parentSiblings = currentCondition.parent.siblings;
@@ -43,7 +38,7 @@ public class Test {
             return new Response(true);
         }
 
-        if (!answer && currentCondition instanceof Or) {
+        if (!answer && currentCondition instanceof Condition.Or) {
             int currentConditionIndex = currentCondition.siblings.indexOf(currentCondition);
             if (currentConditionIndex + 1 < currentCondition.siblings.size()) {
                 return new Response(currentCondition.siblings.get(currentConditionIndex + 1).getDeepestDescendant());
@@ -51,7 +46,7 @@ public class Test {
             return new Response(false);
         }
 
-        if (answer && currentCondition instanceof And) {
+        if (answer && currentCondition instanceof Condition.And) {
             int currentConditionIndex = currentCondition.siblings.indexOf(currentCondition);
             if (currentConditionIndex + 1 < currentCondition.siblings.size()) {
                 return new Response(currentCondition.siblings.get(currentConditionIndex + 1).getDeepestDescendant());
@@ -59,7 +54,7 @@ public class Test {
             return new Response(true);
         }
 
-        if (!answer && currentCondition instanceof And) {
+        if (!answer && currentCondition instanceof Condition.And) {
             int parentIndex = currentCondition.parent.siblings.indexOf(currentCondition.parent);
             List<Condition> parentSiblings = currentCondition.parent.siblings;
             if (parentIndex + 1 < parentSiblings.size()) {
@@ -69,14 +64,6 @@ public class Test {
         }
 
         return null;
-    }
-
-    public Condition firstQuestion() {
-        return getMostBasicQuestion();
-    }
-
-    public String nextQuestion() {
-        return "nextQuestion ?";
     }
 
     private Condition getMostBasicQuestion() {
@@ -97,10 +84,10 @@ public class Test {
                 String segment = remainingString.substring(prevOrIndex, orInd);
                 if (!isWithinParentheses(segment)) {
                     if (separator.equals("&&")) {
-                        output.add(new And(trimAndStripParentheses(segment)));
+                        output.add(new Condition.And(trimAndStripParentheses(segment)));
                     }
                     else {
-                        output.add(new Or(trimAndStripParentheses(segment)));
+                        output.add(new Condition.Or(trimAndStripParentheses(segment)));
                     }
                     prevOrIndex = orInd + 2;
                 }
@@ -112,22 +99,22 @@ public class Test {
                 condition.parent = parent;
                 condition.siblings = output;
                 if (condition.conditionString.indexOf(otherSeparator) > -1) {
-                    if (condition instanceof And) {
-                        ((And) condition).ors = separateSiblings(condition.conditionString, condition, otherSeparator);
+                    if (condition instanceof Condition.And) {
+                        ((Condition.And) condition).ors = separateSiblings(condition.conditionString, condition, otherSeparator);
                     } else {
-                        ((Or) condition).ands = separateSiblings(condition.conditionString, condition, otherSeparator);
+                        ((Condition.Or) condition).ands = separateSiblings(condition.conditionString, condition, otherSeparator);
                     }
                 }
             });
         }
-     return output;
+        return output;
     }
 
     private static void addToOutput(List<Condition> output, String conditionString, String separator) {
         if (separator.equals("&&")) {
-            output.add(new And(conditionString));
+            output.add(new Condition.And(conditionString));
         } else {
-            output.add(new Or(conditionString));
+            output.add(new Condition.Or(conditionString));
         }
     }
 
@@ -143,62 +130,7 @@ public class Test {
         return StringUtils.countMatches(string, "(") > StringUtils.countMatches(string, ")");
     }
 
-    public static class Condition {
-        public String conditionString;
-        public Condition parent;
-        public List<Condition> siblings;
-
-            //TODO make this into a better representation of complexity
-           public int complexity(){
-               return this.conditionString.length();
-           }
-
-           public List<Condition> children() {
-               if (this instanceof Or) {return ((Or) this).ands;}
-               else return ((And) this).ors;
-           }
-
-           public boolean hasChildren() {
-               return this.children() != null;
-           }
-
-           public Condition getDeepestDescendant() {
-               Condition condition = this;
-               while (condition.hasChildren()) {
-                   condition = condition.children().get(0);
-               }
-               return condition;
-           }
-    }
-
-    public static class Or extends Condition {
-        private List<Condition> ands;
-
-        public Or(String condition) {
-            this.conditionString = condition;
-        }
-
-        public Or(List<Condition> ands) {
-            this.ands = ands;
-        }
-
-    }
-
-    public static class And extends Condition {
-        private List<Condition> ors;
-      //  private String conditionString;
-
-        public And(List<Condition> ors) {
-            this.ors = ors;
-        }
-
-        public And(String conditionString) {
-            this.conditionString = conditionString;
-        }
-    }
-
     public static class Response {
-        boolean resolved;
         Boolean resolvedOutcome;
         Condition newQuestion;
 
@@ -207,9 +139,7 @@ public class Test {
         }
 
         public Response(boolean resolvedOutcome) {
-          //  this.resolved = resolved;
             this.resolvedOutcome = resolvedOutcome;
-          //  this.newQuestion = newQuestion;
         }
     }
 }

--- a/src/main/java/FormulaSimplifier/Test.java
+++ b/src/main/java/FormulaSimplifier/Test.java
@@ -1,0 +1,129 @@
+package FormulaSimplifier;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Test {
+
+    List<Or> ors;
+    String testString;
+
+    public Test(List<Or> ors) {
+        this.ors = ors;
+    }
+
+    public Test (String testString) {
+        this.testString = testString;
+        this.ors = separateOrs(testString);
+        this.ors.sort((Condition a1, Condition a2) -> {
+            return a1.complexity() - a2.complexity();
+        });
+    }
+
+    public String nextQuestion() {
+        return getMostBasicQuestion();
+    }
+
+    private String getMostBasicQuestion() {
+        return this.ors.get(0).conditionString;
+    }
+
+    private static List<Or> separateOrs(String testString) {
+        List<Or> output = new ArrayList<>();
+        int prevOrIndex = 0;
+        String remainingString = testString;
+        int numberOfOrs = StringUtils.countMatches(testString, "||");
+        for (int orSequence = 1; orSequence <= numberOfOrs; orSequence++ ) {
+            int orInd = StringUtils.ordinalIndexOf(testString, "||", orSequence);
+            String segment = remainingString.substring(prevOrIndex, orInd);
+            if (!isWithinParentheses(segment)) {
+                output.add(new Or(trimAndStripParentheses(segment)));
+                prevOrIndex = orInd + 2;
+            }
+            if (orSequence == numberOfOrs) {
+                output.add(new Or(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
+            }
+        }
+        output.forEach(condition -> {
+            if (condition.conditionString.indexOf("&&") > -1) {
+                condition.ands = separateAnds(condition.conditionString);
+            }
+        });
+         return output;
+    }
+
+        private static List<And> separateAnds(String testString) {
+        List<And> output = new ArrayList<>();
+        int prevOrIndex = 0;
+        String remainingString = testString;
+        int numberOfOrs = StringUtils.countMatches(testString, "&&");
+        for (int orSequence = 1; orSequence <= numberOfOrs; orSequence++ ) {
+            int orInd = StringUtils.ordinalIndexOf(testString, "&&", orSequence);
+            String segment = remainingString.substring(prevOrIndex, orInd);
+            if (!isWithinParentheses(segment)) {
+                output.add(new And(trimAndStripParentheses(segment)));
+                prevOrIndex = orInd + 2;
+            }
+            if (orSequence == numberOfOrs) {
+                output.add(new And(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
+            }
+        }
+        output.forEach(condition -> {
+            if (condition.conditionString.indexOf("||") > -1) {
+                condition.ors = separateOrs(condition.conditionString);
+            }
+        });
+         return output;
+    }
+
+    private static String trimAndStripParentheses(String string) {
+            string = string.trim();
+            while (string.startsWith("(") && string.endsWith(")")) {
+                string = string.substring(1, string.length()-1).trim();
+            }
+            return string;
+    }
+
+    private static boolean isWithinParentheses(String string) {
+        return StringUtils.countMatches(string, "(") > StringUtils.countMatches(string, ")");
+    }
+
+    public static class Condition {
+        public String conditionString;
+
+           public int complexity(){
+               return this.conditionString.length();
+           }
+
+    }
+
+    public static class Or extends Condition {
+        private List<And> ands;
+
+
+        public Or(String condition) {
+            super();
+            this.conditionString = condition;
+        }
+
+        public Or(List<And> ands) {
+            this.ands = ands;
+        }
+
+    }
+
+    public static class And extends Condition {
+        private List<Or> ors;
+        private String conditionString;
+
+        public And(List<Or> ors) {
+            this.ors = ors;
+        }
+
+        public And(String conditionString) {
+            this.conditionString = conditionString;
+        }
+    }
+}

--- a/src/main/java/FormulaSimplifier/Test.java
+++ b/src/main/java/FormulaSimplifier/Test.java
@@ -82,72 +82,7 @@ public class Test {
     private Condition getMostBasicQuestion() {
         return this.ors.get(0).getDeepestDescendant();
     }
-/*
-    private static List<Condition> separateOrs(String testString, Condition parent) {
-        List<Condition> output = new ArrayList<>();
-        int prevOrIndex = 0;
-        String remainingString = testString;
-        int numberOfOrs = StringUtils.countMatches(testString, "||");
-        if (numberOfOrs == 0) {
-            output.add(new Or(trimAndStripParentheses(testString)));
-        } else {
-            for (int orSequence = 1; orSequence <= numberOfOrs; orSequence++) {
-                int orInd = StringUtils.ordinalIndexOf(testString, "||", orSequence);
-                String segment = remainingString.substring(prevOrIndex, orInd);
-                if (!isWithinParentheses(segment)) {
-                    output.add(new Or(trimAndStripParentheses(segment)));
-                    prevOrIndex = orInd + 2;
-                }
-                if (orSequence == numberOfOrs) {
-                    output.add(new Or(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
-                }
-            }
-            output.forEach(condition -> {
-                ((Or) condition).parent = parent;
-                if (parent != null) {
-                    ((Or) condition).siblings = parent.children();
-                }
-                if (condition.conditionString.indexOf("&&") > -1) {
-                    ((Or) condition).ands = separateAnds(condition.conditionString, condition);
-                }
-            });
-        }
-         return output;
-    }
 
-    private static List<Condition> separateAnds(String testString, Condition parent) {
-        List<Condition> output = new ArrayList<>();
-        int prevOrIndex = 0;
-        String remainingString = testString;
-        int numberOfAnds = StringUtils.countMatches(testString, "&&");
-        if (numberOfAnds == 0) {
-            output.add(new Or(trimAndStripParentheses(testString)));
-        } else {
-            for (int orSequence = 1; orSequence <= numberOfAnds; orSequence++) {
-                int orInd = StringUtils.ordinalIndexOf(testString, "&&", orSequence);
-                String segment = remainingString.substring(prevOrIndex, orInd);
-                if (!isWithinParentheses(segment)) {
-                    output.add(new And(trimAndStripParentheses(segment)));
-                    prevOrIndex = orInd + 2;
-                }
-                if (orSequence == numberOfAnds) {
-                    output.add(new And(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
-                }
-            }
-            output.forEach(condition -> {
-                ((And) condition).parent = parent;
-                if (parent != null) {
-                    ((And) condition).siblings = parent.children();
-                }
-                if (condition.conditionString.indexOf("||") > -1) {
-                    ((And) condition).ors = separateOrs(condition.conditionString, condition);
-
-                }
-            });
-        }
-     return output;
-    }
-*/
     private static List<Condition> separateSiblings(String testString, Condition parent, String separator) {
         String otherSeparator = separator.equals("&&") ? "||" : "&&";
         List<Condition> output = new ArrayList<>();
@@ -155,11 +90,7 @@ public class Test {
         String remainingString = testString;
         int numberOfSiblings = StringUtils.countMatches(testString, separator);
         if (numberOfSiblings == 0) {
-            if (separator.equals("&&")) {
-                output.add(new And(trimAndStripParentheses(testString)));
-            } else {
-                output.add(new Or(trimAndStripParentheses(testString)));
-            }
+            addToOutput(output, trimAndStripParentheses(testString), separator);
         } else {
             for (int orSequence = 1; orSequence <= numberOfSiblings; orSequence++) {
                 int orInd = StringUtils.ordinalIndexOf(testString, separator, orSequence);
@@ -174,12 +105,7 @@ public class Test {
                     prevOrIndex = orInd + 2;
                 }
                 if (orSequence == numberOfSiblings) {
-                    if (separator.equals("&&")) {
-                        output.add(new And(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
-                    }
-                    else {
-                        output.add(new Or(trimAndStripParentheses(remainingString.substring(prevOrIndex))));
-                    }
+                    addToOutput(output, trimAndStripParentheses(remainingString.substring(prevOrIndex)), separator);
                 }
             }
             output.forEach(condition -> {
@@ -195,6 +121,14 @@ public class Test {
             });
         }
      return output;
+    }
+
+    private static void addToOutput(List<Condition> output, String conditionString, String separator) {
+        if (separator.equals("&&")) {
+            output.add(new And(conditionString));
+        } else {
+            output.add(new Or(conditionString));
+        }
     }
 
     private static String trimAndStripParentheses(String string) {
@@ -214,6 +148,7 @@ public class Test {
         public Condition parent;
         public List<Condition> siblings;
 
+            //TODO make this into a better representation of complexity
            public int complexity(){
                return this.conditionString.length();
            }

--- a/src/main/java/FormulaSimplifier/Verification.java
+++ b/src/main/java/FormulaSimplifier/Verification.java
@@ -1,0 +1,26 @@
+package FormulaSimplifier;
+
+public enum Verification {
+    QUESTION_COLON("?","question mark", "question marks",":", "colon", "colons",true),
+    PARENTHESES("(","opening parenthesis","opening parentheses",")","closing parenthesis","closing parentheses", false);
+
+    public final String opener;
+    public final String openerName;
+    public final String openerNamePlural;
+    public final String closer;
+    public final String closerName;
+    public final String closerNamePlural;
+    public final Boolean mandatory;
+
+
+    Verification(String opener, String openerName, String openerNamePlural, String closer, String closerName, String closerNamePlural, Boolean mandatory) {
+        this.opener = opener;
+        this.openerName = openerName;
+        this.openerNamePlural = openerNamePlural;
+        this.closer = closer;
+        this.closerName = closerName;
+        this.closerNamePlural = closerNamePlural;
+        this.mandatory = mandatory;
+    }
+
+}

--- a/src/test/java/FormulaSimplifier/ConditionTest.java
+++ b/src/test/java/FormulaSimplifier/ConditionTest.java
@@ -1,0 +1,19 @@
+package FormulaSimplifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConditionTest {
+
+    @org.junit.jupiter.api.Test
+    void complexity() {
+        // A test with two children, one of which also has a test with two children
+        Test test = new Test("foorab || (foo && (bar || rab))");
+        assertEquals (5, test.getOrs().get(1).complexity());
+        // A test with two children, one of which has a test with three children
+        test = new Test("foorab || (foo && (bar || rab || bra))");
+        assertEquals (6, test.getOrs().get(1).complexity());
+        // A test with two children, both of which have tests with two children
+        test = new Test("foorab || ((foo || oof) && (bar || bra))");
+        assertEquals (7, test.getOrs().get(1).complexity());
+    }
+}


### PR DESCRIPTION
### Split children
Incorporated change so that a clause with multiple ANDs and ORs will be broken down into its most basic parts and skipped as soon as resolved. For example

- If an OR condition is met, no further ORs in the same family will be asked and the overall condition will be resolved as true.

- If an AND condition is false, no further ANDs  in the same family will be asked and the overall condition will be resolved as false.

- If an OR condition is resolved as false, its parent AND will therefore be false but if its grandparent OR has siblings then a sibling will be returned

e.g.

```((foo && (bar || rab)) || foobar) ? true : false```

If `foo` is true, but `bar` and `rab` are both false, then bar || rab is false, hence `(foo && (bar || rab)` is false, but there is still an opportunity for the overall formula to return true if `foobar` is true. `foobar` is a sibling of `(foo && (bar || rab)` which is a grandparent of `rab`.

### Other refactoring
Generally tidied up old code to make more OO-friendly and follow more best practices (it was a useful exercise revisiting some of my very old code!)


